### PR TITLE
unify path resolution in Device Catalog for dev and installed builds

### DIFF
--- a/src/libraries/qcommon-console/ConsoleApplicationEnhancements.cpp
+++ b/src/libraries/qcommon-console/ConsoleApplicationEnhancements.cpp
@@ -28,6 +28,10 @@ const QString kAppName("QTAC");
 
 QString applicationBinPath()
 {
+	const QString appDir = QDir::cleanPath(QCoreApplication::applicationDirPath());
+	if (!appDir.isEmpty() && QDir(appDir).exists())
+		return appDir + "/";
+
 	QString result;
 
 #ifdef Q_OS_WIN
@@ -51,7 +55,15 @@ QString applicationDataPath()
 	QString result = "../../../../configurations/";
 
 	if (QDir(result).exists() == false)
-		QDir().mkpath(result);
+		{
+			#ifdef Q_OS_WIN
+				result = "C:/ProgramData/Qualcomm/" + kAppName + "/configurations/";
+			#endif
+
+			#ifdef Q_OS_LINUX
+				result = "/var/lib/qcom/data/" + kAppName + "/configurations/";
+			#endif
+		}
 
 	return result;
 }

--- a/src/libraries/qcommon-console/ConsoleApplicationEnhancements.cpp
+++ b/src/libraries/qcommon-console/ConsoleApplicationEnhancements.cpp
@@ -28,25 +28,8 @@ const QString kAppName("QTAC");
 
 QString applicationBinPath()
 {
-	const QString appDir = QDir::cleanPath(QCoreApplication::applicationDirPath());
-	if (!appDir.isEmpty() && QDir(appDir).exists())
-		return appDir + "/";
-
-	QString result;
-
-#ifdef Q_OS_WIN
-	result = "C:/Program Files (x86)/Qualcomm/" + kAppName + "/";
-#endif
-
-#ifdef Q_OS_LINUX
-	result = "/opt/qcom/" + kAppName + "/bin/";
-#endif
-
-	result = QDir::cleanPath(result);
-
-	if (QDir(result).exists() == false)
-		QDir().mkpath(result);
-
+	const QString result = QDir::cleanPath(QCoreApplication::applicationDirPath())
+	                       + QDir::separator();
 	return result;
 }
 

--- a/src/libraries/qcommon-console/USBDescriptors.cpp
+++ b/src/libraries/qcommon-console/USBDescriptors.cpp
@@ -231,7 +231,7 @@ bool USBDescriptors::read(QJsonObject& parentLevel)
 					if (catalogData.contains(kRevisionNumber))
 						usbDescriptor._revision = static_cast<quint32>(catalogData[kRevisionNumber].toInt());
 
-		            if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
+					if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
 						usbDescriptor._configurationFilePath = catalogData[kConfigFilePath].toString().toLatin1();
 
 #ifdef Q_OS_LINUX

--- a/src/libraries/qcommon-console/USBDescriptors.cpp
+++ b/src/libraries/qcommon-console/USBDescriptors.cpp
@@ -234,9 +234,9 @@ bool USBDescriptors::read(QJsonObject& parentLevel)
 		            if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
 						usbDescriptor._configurationFilePath = catalogData[kConfigFilePath].toString().toLatin1();
 
-					#ifdef Q_OS_LINUX
-						usbDescriptor._configurationFilePath = expandPath(QString(usbDescriptor._configurationFilePath)).toLatin1();
-					#endif
+#ifdef Q_OS_LINUX
+					usbDescriptor._configurationFilePath = expandPath(QString(usbDescriptor._configurationFilePath)).toLatin1();
+#endif
 
 					if (usbDescriptor._debugBoardType == eFTDI)
 					{

--- a/src/libraries/qcommon-console/USBDescriptors.cpp
+++ b/src/libraries/qcommon-console/USBDescriptors.cpp
@@ -231,12 +231,19 @@ bool USBDescriptors::read(QJsonObject& parentLevel)
 					if (catalogData.contains(kRevisionNumber))
 						usbDescriptor._revision = static_cast<quint32>(catalogData[kRevisionNumber].toInt());
 
-					if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
-						usbDescriptor._configurationFilePath = catalogData[kConfigFilePath].toString().toLatin1();
-
-#ifdef Q_OS_LINUX
-					usbDescriptor._configurationFilePath = expandPath(QString(usbDescriptor._configurationFilePath)).toLatin1();
-#endif
+		            if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
+					{
+						const QString rawPath = catalogData[kConfigFilePath].toString();
+						const QString fileName = QFileInfo(rawPath).fileName();
+						if (!fileName.isEmpty())
+						{
+							const QString resolvedPath = QFileInfo(
+								QDir::cleanPath(tacConfigRoot() + fileName)
+							).absoluteFilePath();
+							if (QFileInfo::exists(resolvedPath))
+								usbDescriptor._configurationFilePath = resolvedPath.toLatin1();
+						}
+					}
 
 					if (usbDescriptor._debugBoardType == eFTDI)
 					{

--- a/src/libraries/qcommon-console/USBDescriptors.cpp
+++ b/src/libraries/qcommon-console/USBDescriptors.cpp
@@ -232,18 +232,11 @@ bool USBDescriptors::read(QJsonObject& parentLevel)
 						usbDescriptor._revision = static_cast<quint32>(catalogData[kRevisionNumber].toInt());
 
 		            if (catalogData.contains(kConfigFilePath) && catalogData[kConfigFilePath].isString())
-					{
-						const QString rawPath = catalogData[kConfigFilePath].toString();
-						const QString fileName = QFileInfo(rawPath).fileName();
-						if (!fileName.isEmpty())
-						{
-							const QString resolvedPath = QFileInfo(
-								QDir::cleanPath(tacConfigRoot() + fileName)
-							).absoluteFilePath();
-							if (QFileInfo::exists(resolvedPath))
-								usbDescriptor._configurationFilePath = resolvedPath.toLatin1();
-						}
-					}
+						usbDescriptor._configurationFilePath = catalogData[kConfigFilePath].toString().toLatin1();
+
+					#ifdef Q_OS_LINUX
+						usbDescriptor._configurationFilePath = expandPath(QString(usbDescriptor._configurationFilePath)).toLatin1();
+					#endif
 
 					if (usbDescriptor._debugBoardType == eFTDI)
 					{


### PR DESCRIPTION
## Pull Request

**Description**
-unify path resolution in Device Catalog for dev and installed builds
-Replace the TACConfigEditor-specific existence check in applicationBinPath()
with QCoreApplication::applicationDirPath(), which is always the directory
of the running executable. 

**Related Issue**

**Type of Change**
Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- 
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

**Additional Context**

