### PR TITLE
devicelist: add IQ10 RRD (IQ10 Robotics Reference Design) board

### DIFF
--- a/configurations/devicelist.json
+++ b/configurations/devicelist.json
@@ -558,6 +558,15 @@
             "usb_descriptor": "KARUSSELL"
         },
         {
+            "configPath": "../../../../configurations/TAC_PIC32CXAuto_54.tcnf",
+            "debugBoardType": 4,
+            "description": "IQ10 Robotics Reference Design",
+            "name": "IQ10 RRD",
+            "platform_id": 54,
+            "revision": 6,
+            "usb_descriptor": "IQ10RRD"
+        },
+        {
             "chip1BusSet": 12,
             "chip2BusSet": 0,
             "chip3BusSet": 0,


### PR DESCRIPTION
## Pull Request

**Description**
The IQ10 RRD board uses the same TAC_PIC32CXAuto_54.tcnf config as the NordAu RIDE board. Add it as a separate catalog entry so pytac [1] (which identifies PIC32CX boards by the serial-number prefix before "XX") can resolve the correct config for IQ10RRD boards.

**Type of Change**
Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[1] https://github.com/qualcomm/pytac