### PR TITLE
Allow easily using the distro Qt binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,16 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Multimedia)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Concurrent Gui Multimedia MultimediaWidgets Network SerialPort Widgets Xml)
 
-qt_standard_project_setup(REQUIRES 6.9)
+qt_standard_project_setup(REQUIRES 6.4)
+
+# qt_generate_deploy_app_script()'s option to receive the generated script's
+# path was renamed OUTPUT_SCRIPT in Qt 6.5; distro-packaged Qt as old as 6.4
+# only understands the original FILENAME_VARIABLE name.
+if(QT_VERSION VERSION_LESS 6.5)
+    set(QT_DEPLOY_SCRIPT_KEYWORD FILENAME_VARIABLE)
+else()
+    set(QT_DEPLOY_SCRIPT_KEYWORD OUTPUT_SCRIPT)
+endif()
 
 add_subdirectory(third-party)
 add_subdirectory(src/libraries)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ QTAC is a software suite that enables users to control Qualcomm devices remotely
 | **Compiler** | [MSVC 2022](https://aka.ms/vs/17/release/vs_community.exe) / GCC | MSVC 2022 / GCC-11, G++-11, GLIBC-2.35 |
 | **Build System** | [CMake](https://cmake.org/download/) | 3.22+ |
 | **Build Tool** | [Ninja](https://ninja-build.org/) (via Qt installer, system package manager, or direct download) | 1.10+ |
-| **UI Framework** | [Qt Open-source](https://www.qt.io/download-qt-installer-oss) | 6.9.0+ |
+| **UI Framework** | Qt Open-source (Linux: `apt`, e.g. `qt6-base-dev`; Windows: [Qt Online Installer](https://www.qt.io/download-qt-installer-oss)) | 6.4.0+ |
 
 > [!NOTE]
 > Review license terms for [Visual Studio](https://visualstudio.microsoft.com/license-terms/) and [Qt](https://www.qt.io/development/download-open-source). MSVC 2022 is linked as Qt does not yet support later MSVC versions.
@@ -137,22 +137,24 @@ __Builds\ARM64\Release\QTAC.exe
 > - Using `sudo apt install <package>` will update setup packages. Review command usage to prevent issues with other applications.
 
 1. **Qt Installation** (choose one):
-   
-   **Option A**: Qt Online Installer
-   - Install Qt 6.9+ for **GCC 64-bit** and **Qt Serial Port** and **Qt Multimedia** components using [Qt Online Installer](https://www.qt.io/download-qt-installer-oss)
-   
-   **Option B**: Quick Installation via apt
+
+   **Option A**: Quick installation via apt (recommended)
    ```bash
-   sudo apt install qt6-base-dev qt6-serialport-dev qt6-multimedia-dev
+   sudo apt install cmake ninja-build qt6-base-dev qt6-serialport-dev qt6-multimedia-dev
    ```
+   `build.sh` automatically detects and uses this system Qt installation — no
+   environment variable needed.
+
+   **Option B**: Qt Online Installer
+   - Install Qt 6.4+ for **GCC 64-bit** and **Qt Serial Port** and **Qt Multimedia** components using [Qt Online Installer](https://www.qt.io/download-qt-installer-oss)
+   - Set the `QTBIN` environment variable to opt into this installation instead of the system Qt:
+     ```bash
+     export QTBIN=/path/to/Qt/directory/<version>/gcc_64/bin
+     ```
 2. **Runtime Dependencies**:
    ```bash
    sudo cp udev-rules/99-QTAC-USB.rules /etc/udev/rules.d/
    sudo udevadm control --reload
-   ```
-3. **Environment Variable**:
-   ```bash
-   export QTBIN=/path/to/Qt/directory/<version>/gcc_64/bin
    ```
 
 ### Build & Usage

--- a/build.sh
+++ b/build.sh
@@ -5,42 +5,66 @@
 
 set -e
 
-if [ -z "$QTBIN" ]; then
+###############################################################################
+# Locate Qt: use QTBIN (Qt Online Installer tree) if set, else host Qt
+###############################################################################
+
+USING_SYSTEM_QT=0
+MISSING_PACKAGES=()
+
+command -v cmake &>/dev/null || MISSING_PACKAGES+=("cmake")
+command -v ninja &>/dev/null || MISSING_PACKAGES+=("ninja-build")
+command -v g++   &>/dev/null || MISSING_PACKAGES+=("build-essential")
+
+if [ -n "$QTBIN" ]; then
+    if [ ! -d "$QTBIN" ]; then
+        echo ""
+        echo "ERROR: QTBIN directory does not exist: $QTBIN"
+        echo "       Install Qt 6.4+ via the Qt Online Installer (https://www.qt.io/download-qt-installer-oss)"
+        echo "       and include the GCC 64-bit component, then update QTBIN."
+        exit 1
+    fi
+
+    if ! echo "$QTBIN" | grep -q "gcc_64"; then
+        echo ""
+        echo "ERROR: QTBIN does not point to a GCC 64-bit Qt installation."
+        echo "       QTBIN is currently: $QTBIN"
+        echo "       A Linux build requires the Qt GCC 64-bit component. QTBIN must contain 'gcc_64', e.g.:"
+        echo "         export QTBIN=/path/to/Qt/<version>/gcc_64/bin"
+        exit 1
+    fi
+
+    QT_PREFIX="$(dirname "$QTBIN")"
+    export PATH="$QTBIN:$PATH"
+else
+    USING_SYSTEM_QT=1
+
+    if command -v qmake6 &>/dev/null; then
+        QT_PREFIX="$(qmake6 -query QT_INSTALL_PREFIX)"
+    else
+        MISSING_PACKAGES+=("qt6-base-dev")
+    fi
+
+    dpkg -s qt6-multimedia-dev &>/dev/null || MISSING_PACKAGES+=("qt6-multimedia-dev")
+    dpkg -s qt6-serialport-dev &>/dev/null || MISSING_PACKAGES+=("qt6-serialport-dev")
+fi
+
+if [ "${#MISSING_PACKAGES[@]}" -gt 0 ]; then
     echo ""
-    echo "ERROR: QTBIN is not set."
-    echo "       QTBIN must point to the Qt bin directory, e.g.:"
-    echo "         export QTBIN=/path/to/Qt/<version>/gcc_64/bin"
+    echo "ERROR: Missing required build tools/packages: ${MISSING_PACKAGES[*]}"
+    echo "       Install them with:"
+    echo "         sudo apt install ${MISSING_PACKAGES[*]}"
     echo "       Then re-run this script."
-    exit 1
-fi
-
-if [ ! -d "$QTBIN" ]; then
     echo ""
-    echo "ERROR: QTBIN directory does not exist: $QTBIN"
-    echo "       Install Qt 6.9+ via the Qt Online Installer (https://www.qt.io/download-qt-installer-oss)"
-    echo "       and include the GCC 64-bit component, then update QTBIN."
+    echo "       (Alternatively, install Qt via the Qt Online Installer"
+    echo "       (https://www.qt.io/download-qt-installer-oss) and set QTBIN to its"
+    echo "       gcc_64/bin directory instead of using the system Qt packages.)"
     exit 1
 fi
 
-if ! echo "$QTBIN" | grep -q "gcc_64"; then
-    echo ""
-    echo "ERROR: QTBIN does not point to a GCC 64-bit Qt installation."
-    echo "       QTBIN is currently: $QTBIN"
-    echo "       A Linux build requires the Qt GCC 64-bit component. QTBIN must contain 'gcc_64', e.g.:"
-    echo "         export QTBIN=/path/to/Qt/<version>/gcc_64/bin"
-    exit 1
+if [ "$USING_SYSTEM_QT" -eq 1 ]; then
+    echo "Using host Qt installation: $QT_PREFIX"
 fi
-
-if ! command -v ninja &>/dev/null; then
-    echo ""
-    echo "ERROR: ninja not found in PATH."
-    echo "       Install ninja via your package manager, e.g.:"
-    echo "         sudo apt install ninja-build"
-    echo "       Or via the Qt installer (Tools > Ninja)."
-    exit 1
-fi
-
-export PATH="$QTBIN:$PATH"
 
 ###############################################################################
 # Clean start
@@ -53,7 +77,7 @@ rm -rf build __Builds
 ###############################################################################
 
 cmake -S . -B build/Debug \
-    -DCMAKE_PREFIX_PATH="$(dirname "$QTBIN")" \
+    -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
     -DCMAKE_COLOR_DIAGNOSTICS=ON \
     -DCMAKE_GENERATOR=Ninja \
     -DCMAKE_BUILD_TYPE=Debug \
@@ -65,11 +89,21 @@ cmake --build build/Debug
 ###############################################################################
 
 cmake -S . -B build/Release \
-    -DCMAKE_PREFIX_PATH="$(dirname "$QTBIN")" \
+    -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
     -DCMAKE_COLOR_DIAGNOSTICS=ON \
     -DCMAKE_GENERATOR=Ninja \
     -DCMAKE_BUILD_TYPE=Release
 cmake --build build/Release
+
+if [ "$USING_SYSTEM_QT" -eq 1 ]; then
+    echo ""
+    echo "=========================================================="
+    echo "Using system Qt — skipping runtime bundling"
+    echo "=========================================================="
+    echo "Binaries link against the host's installed Qt6 packages."
+    echo "Check __Builds directory"
+    exit 0
+fi
 
 ###############################################################################
 # Qt Runtime Deployment
@@ -80,7 +114,7 @@ echo "=========================================================="
 echo "Deploying Qt Runtime"
 echo "=========================================================="
 
-QT_ROOT="$(dirname "$QTBIN")"
+QT_ROOT="$QT_PREFIX"
 
 DEPLOY_BIN_DIR="__Builds/Linux/Release/bin"
 DEPLOY_LIB_DIR="__Builds/Linux/Release/lib"

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -8,6 +8,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-qt_standard_project_setup(REQUIRES 6.9)
+qt_standard_project_setup(REQUIRES 6.4)
 
 add_subdirectory(C++/TACDev)

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-qt_standard_project_setup(REQUIRES 6.9)
+qt_standard_project_setup(REQUIRES 6.4)
 
 add_subdirectory(devlist)
 add_subdirectory(tacdump)

--- a/src/applications/device-catalog/CMakeLists.txt
+++ b/src/applications/device-catalog/CMakeLists.txt
@@ -89,7 +89,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET DeviceCatalog
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/devlist/CMakeLists.txt
+++ b/src/applications/devlist/CMakeLists.txt
@@ -53,7 +53,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET ${APP_NAME}
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/ftdi-check/CMakeLists.txt
+++ b/src/applications/ftdi-check/CMakeLists.txt
@@ -83,7 +83,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET FTDICheck
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/programmers/CMakeLists.txt
+++ b/src/applications/programmers/CMakeLists.txt
@@ -8,6 +8,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-qt_standard_project_setup(REQUIRES 6.9)
+qt_standard_project_setup(REQUIRES 6.4)
 
 add_subdirectory(lite-programmer)

--- a/src/applications/programmers/lite-programmer/CMakeLists.txt
+++ b/src/applications/programmers/lite-programmer/CMakeLists.txt
@@ -56,7 +56,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET ${APP_NAME}
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/tac-configuration-editor/CMakeLists.txt
+++ b/src/applications/tac-configuration-editor/CMakeLists.txt
@@ -100,7 +100,7 @@ install(TARGETS ${APP_NAME}
 )
 
 qt_generate_deploy_app_script(TARGET ${APP_NAME}
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/tacdump/CMakeLists.txt
+++ b/src/applications/tacdump/CMakeLists.txt
@@ -63,7 +63,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET ${APP_NAME}
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/test-automation-controller/CMakeLists.txt
+++ b/src/applications/test-automation-controller/CMakeLists.txt
@@ -104,7 +104,7 @@ install(TARGETS TAC
 
 qt_generate_deploy_app_script(
     TARGET TAC
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/applications/updatedevicelist/CMakeLists.txt
+++ b/src/applications/updatedevicelist/CMakeLists.txt
@@ -48,7 +48,7 @@ install(TARGETS ${APP_NAME}
 
 qt_generate_deploy_app_script(
     TARGET ${APP_NAME}
-    OUTPUT_SCRIPT deploy_script
+    ${QT_DEPLOY_SCRIPT_KEYWORD} deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src/libraries/CMakeLists.txt
+++ b/src/libraries/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
-qt_standard_project_setup(REQUIRES 6.9)
+qt_standard_project_setup(REQUIRES 6.4)
 
 add_subdirectory(qcommon-console)
 add_subdirectory(qcommon)

--- a/src/libraries/qcommon/TableCheckBox.cpp
+++ b/src/libraries/qcommon/TableCheckBox.cpp
@@ -16,7 +16,13 @@ TableCheckBox::TableCheckBox
 	// Initialize the check-box
 	_checkBox = new QCheckBox(this);
 
+	// QCheckBox::checkStateChanged() replaced stateChanged() in Qt 6.7; stateChanged()
+	// is compiled out on newer Qt by QT_DISABLE_DEPRECATED_UP_TO, so branch on version.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 	connect(_checkBox, &QCheckBox::checkStateChanged, this, [=, this](bool newState){ emit checkStateChanged(newState); });
+#else
+	connect(_checkBox, &QCheckBox::stateChanged, this, [=, this](bool newState){ emit checkStateChanged(newState); });
+#endif
 
 	// Prepare check box layout
 	QHBoxLayout* layoutCheckBox = new QHBoxLayout(this);


### PR DESCRIPTION
## Pull Request

**Description**
Most Linux users don't want to install a pre-made package from the Qt website and would prefer to use the distro-provided set. This is also more or less also a pre-requisite for distro packaging. This PR also bumps down the Qt requirement from 6.9 to 6.4 through a trivial change, to allow a broader range of non-bleeding-edge distros in.

The current build.sh really insists on having a user-provided path to the Qt toolchain, with a structure that only exists if the website package is used, so that is changed accordingly.

**Related Issue**
n/a

**Type of Change**
Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works # built on ubuntu 24.04
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

**Additional Context**
Add any other context or screenshots about the pull request here.
